### PR TITLE
Use sphere for PolyHaven default preview geom

### DIFF
--- a/javascript/JsPolyHaven/main.js
+++ b/javascript/JsPolyHaven/main.js
@@ -19,7 +19,7 @@ const mainSpinner = document.getElementById('mainSpinner');
 const materialModal = new bootstrap.Modal(document.getElementById('materialModal'));
 
 // Target URL for the viewer page
-let targetURL = "https://kwokcb.github.io/MaterialXLab/javascript/shader_utilities/dist/index.html?viewerOnly=1";
+let targetURL = "https://kwokcb.github.io/MaterialXLab/javascript/shader_utilities/dist/index.html?viewerOnly=1&geom=Geometry/sphere.glb";
 // Set for local testing
 //targetURL = "http://localhost:8000/javascript/shader_utilities/dist/index.html?viewerOnly=1";
 


### PR DESCRIPTION
## Change

Change default geom for PolyHaven to sphere (from teapot) to match previews.

### Example

<img width="753" height="577" alt="Screenshot 2026-03-06 at 23 49 16" src="https://github.com/user-attachments/assets/3931a671-1a18-4a06-82bd-ffac3f40e372" />


